### PR TITLE
[FIX] flake8

### DIFF
--- a/auditlog/models/rule.py
+++ b/auditlog/models/rule.py
@@ -292,7 +292,6 @@ class auditlog_rule(models.Model):
         if new_values is None:
             new_values = EMPTY_DICT
         log_model = self.env['auditlog.log']
-        ir_model = self.env['ir.model']
         for res_id in res_ids:
             model_model = self.env[res_model]
             res_name = model_model.browse(res_id).name_get()

--- a/auditlog/tests/test_auditlog.py
+++ b/auditlog/tests/test_auditlog.py
@@ -24,33 +24,32 @@ from openerp.tests.common import TransactionCase
 class TestAuditlog(TransactionCase):
     def test_LogCreation(self):
         auditlog_log = self.env['auditlog.log']
-        user_model_id = self.env.ref('base.model_res_users').id
+        groups_model_id = self.env.ref('base.model_res_groups').id
         self.env['auditlog.rule'].create({
-            'name': 'testrule for users',
-            'model_id': user_model_id,
+            'name': 'testrule for groups',
+            'model_id': groups_model_id,
             'log_create': True,
             'log_write': True,
             'log_unlink': True,
             'state': 'subscribed',
         })
-        user = self.env['res.users'].create({
-            'login': 'testuser',
-            'name': 'testuser',
+        group = self.env['res.groups'].create({
+            'name': 'testgroup',
         })
         self.assertTrue(auditlog_log.search([
-            ('model_id', '=', user_model_id),
+            ('model_id', '=', groups_model_id),
             ('method', '=', 'create'),
-            ('res_id', '=', user.id),
+            ('res_id', '=', group.id),
         ]))
-        user.write({'name': 'Test User'})
+        group.write({'name': 'Testgroup'})
         self.assertTrue(auditlog_log.search([
-            ('model_id', '=', user_model_id),
+            ('model_id', '=', groups_model_id),
             ('method', '=', 'write'),
-            ('res_id', '=', user.id),
+            ('res_id', '=', group.id),
         ]))
-        user.unlink()
+        group.unlink()
         self.assertTrue(auditlog_log.search([
-            ('model_id', '=', user_model_id),
+            ('model_id', '=', groups_model_id),
             ('method', '=', 'unlink'),
-            ('res_id', '=', user.id),
+            ('res_id', '=', group.id),
         ]))


### PR DESCRIPTION
The previous commits introduced a flake8 warning and creating users during tests goes wrong because the tests install the mail module, but this module does not depend on it. So I simply use another model now.
