### PR TITLE
[ADD] migration script

### DIFF
--- a/auditlog/migrations/8.0.1.0/pre-migration.py
+++ b/auditlog/migrations/8.0.1.0/pre-migration.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    OpenERP, Open Source Management Solution
+#    This module copyright (C) 2015 Therp BV (<http://therp.nl>).
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+from openerp.addons.auditlog import migrate_from_audittrail
+
+
+def migrate(cr, version):
+    """if we migrate from an older version, it's a migration from audittrail"""
+    migrate_from_audittrail(cr)


### PR DESCRIPTION
this is for the case that you do a migration with OpenUpgrade. In that case, audittrail is renamed to auditlog, which causes the init hook not being called (the module is not newly installed, but upgraded from the point of view of OpenUpgrade). See https://github.com/OpenUpgrade/OpenUpgrade/pull/239
